### PR TITLE
Simplificación del código

### DIFF
--- a/codigo.php
+++ b/codigo.php
@@ -1,10 +1,12 @@
 <?php
 /* Procura evitar lógica inversa y, a ser posible, el operador fusión de null */
-switch (substr(
-    $_SERVER['HTTP_ACCEPT_LANGUAGE']) ?? 'es',
-    0,
-    2
-)) {
+switch (
+    substr(
+        $_SERVER['HTTP_ACCEPT_LANGUAGE']) ?? 'es',
+        0,
+        2
+    )
+) {
     //El error es que si un usuario cuyo idioma es castellano visita la raiz, es redirigido nuevamente aunque YA ESTÉ en la raiz. La idea es que quizá con una cookie detecte si ya está en la raiz y no haga la redirección para evitar el error de "TOO MANY REDIRECTS".
     case 'es':
         /* No tenemos que redirigir a ningún sitio */

--- a/codigo.php
+++ b/codigo.php
@@ -1,26 +1,20 @@
 <?php
-//Este código está hasta arriba de mi index.php.
-//Y el  idioma principal es castellano
-$accept_languaje = !empty($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : 'es';
-$main_languaje   = substr($accept_languaje, 0, 2);
-//tanto el index, como "en.php" y "pt.php" están en la raiz del dominio
-switch ($main_languaje):
+/* Procura evitar lógica inversa y, a ser posible, el operador fusión de null */
+switch (substr(
+    $_SERVER['HTTP_ACCEPT_LANGUAGE']) ?? 'es',
+    0,
+    2
+)) {
     //El error es que si un usuario cuyo idioma es castellano visita la raiz, es redirigido nuevamente aunque YA ESTÉ en la raiz. La idea es que quizá con una cookie detecte si ya está en la raiz y no haga la redirección para evitar el error de "TOO MANY REDIRECTS".
     case 'es':
-        exit(header("Location: https://ejemplo.com/"));
-    case 'en':
-        exit(header("Location: https://ejemplo.com/en.php"));
+        /* No tenemos que redirigir a ningún sitio */
+        break;
     case 'pt':
-        exit(header("Location: https://ejemplo.com/pt.php"));
-endswitch;
-if (false !== strpos($accept_languaje, 'es')) {
-    exit(header("Location: https://ejemplo.com/"));
+        header("Location: https://ejemplo.com/pt.php");
+        exit();
+        break;
+    default:
+        /* Ante cualquier otro idioma que no sea "es" o "pt" asumimos el inglés */
+        header("Location: https://ejemplo.com/en.php");
+        exit();
 }
-if (false !== strpos($accept_languaje, 'en')) {
-    exit(header("Location: https://ejemplo.com/en.php"));
-}
-if (false !== strpos($accept_languaje, 'pt')) {
-    exit(header("Location: https://ejemplo.com/pt.php"));
-}
-//Si el usuario habla otro idioma, se redirecciona a la versión en Inglés
-exit(header("Location: https://ejemplo.com/en.php"));

--- a/codigo.php
+++ b/codigo.php
@@ -1,11 +1,7 @@
 <?php
 /* Procura evitar lógica inversa y, a ser posible, el operador fusión de null */
 switch (
-    substr(
-        $_SERVER['HTTP_ACCEPT_LANGUAGE']) ?? 'es',
-        0,
-        2
-    )
+    substr($_SERVER['HTTP_ACCEPT_LANGUAGE']) ?? 'es', 0, 2)
 ) {
     //El error es que si un usuario cuyo idioma es castellano visita la raiz, es redirigido nuevamente aunque YA ESTÉ en la raiz. La idea es que quizá con una cookie detecte si ya está en la raiz y no haga la redirección para evitar el error de "TOO MANY REDIRECTS".
     case 'es':


### PR DESCRIPTION
He simplificado el código, haciendo algunos cambios en el código:

* Uso del operador de fusión de null (`??`) en lugar del operador ternario (`?:`).
* Separación del envío de cabeceras de la finalización de la ejecución del script.
* Evitamos una redirección en caso de estar usando la lengua castellana, ya que estamos en el script adecuado.
* Evitamos el cierre de PHP (`?>`) cuando solo hay código fuente en él.