### PR TITLE
Errata al limpiar código

### DIFF
--- a/codigo.php
+++ b/codigo.php
@@ -1,7 +1,7 @@
 <?php
 /* Procura evitar lógica inversa y, a ser posible, el operador fusión de null */
 switch (
-    substr($_SERVER['HTTP_ACCEPT_LANGUAGE']) ?? 'es', 0, 2)
+    substr($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? 'es', 0, 2)
 ) {
     //El error es que si un usuario cuyo idioma es castellano visita la raiz, es redirigido nuevamente aunque YA ESTÉ en la raiz. La idea es que quizá con una cookie detecte si ya está en la raiz y no haga la redirección para evitar el error de "TOO MANY REDIRECTS".
     case 'es':


### PR DESCRIPTION
Dejé un paréntesis por error heredado del uso del operador ternario.